### PR TITLE
Revert "Update cache to be generic type"

### DIFF
--- a/src/cache_test.go
+++ b/src/cache_test.go
@@ -40,7 +40,7 @@ func TestBasicLRUFail(t *testing.T) {
 		return
 	}
 
-	var cache Cache
+	var cache LRUCache
 	cache.Init(CACHE_SIZE)
 
 	for i := 0; i < 2; i++ {
@@ -84,8 +84,8 @@ func TestBasicLRUSuccess(t *testing.T) {
 		fmt.Printf("\tignoring, CACHE_SIZE too big\n")
 		return
 	}
-
-	var cache Cache
+	
+	var cache LRUCache
 	cache.Init(CACHE_SIZE)
 
 	for i := 0; i < 2; i++ {

--- a/src/interfaces.go
+++ b/src/interfaces.go
@@ -1,0 +1,11 @@
+package cache
+
+import (
+	"os"
+)
+
+type Cache interface {
+	Init(cacheSize int)
+	Fetch(name string) (*os.File, error)
+	Report() (int, int) // Cache hits, cache misses
+}

--- a/src/lru_cache.go
+++ b/src/lru_cache.go
@@ -6,18 +6,17 @@ import (
 )
 
 /********************************
-Cache supports the following external API to users
+LRU Cache supports the following external API to users
 
-c.Init(cacheSize int, cacheType CacheType)
-    Initializes a cache with eviction policy and prefetch defined by cache type
+c.Init(cacheSize int)
+    Initializes a cache with LRU eviction policy and no prefetching
 c.Report() (hits, misses)
     Get a report of the hits and misses  TODO: Do we want a version number or
     timestamp mechanism of any form here?
-c.Fetch(name string) (*os.File, error)
 
 *********************************/
 
-type Cache struct {
+type LRUCache struct {
 	mu          sync.Mutex          // Lock to protect shared access to cache
 	misses		int
 	hits		int
@@ -28,7 +27,7 @@ type Cache struct {
 }
 
 
-func (c *Cache) Fetch(name string) (*os.File, error) {
+func (c *LRUCache) Fetch(name string) (*os.File, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -49,14 +48,14 @@ func (c *Cache) Fetch(name string) (*os.File, error) {
 }
 
 
-func (c *Cache) Report() (int, int) {
+func (c *LRUCache) Report() (int, int) {
     c.mu.Lock()
     defer c.mu.Unlock()
 	return c.hits, c.misses
 }
 
 
-func (c *Cache) Init(cacheSize int){
+func (c *LRUCache) Init(cacheSize int){
 	c.misses = 0
 	c.hits = 0
     c.cacheSize = cacheSize
@@ -67,7 +66,7 @@ func (c *Cache) Init(cacheSize int){
 
 
 // assumes mu is Locked
-func (c *Cache) replace(name string, file *os.File) {
+func (c *LRUCache) replace(name string, file *os.File) {
 	c.cache[name] = file
 	c.heap.Insert(name, c.timestamp)
 	if c.heap.n > c.cacheSize {


### PR DESCRIPTION
Reverts rootjalex/smart-cache#1

We want the interface Cache to remain, we will use embedding  (https://yourbasic.org/golang/inheritance-object-oriented/) instead.