### PR TITLE
BUG FIX: Fix incorrect make command for GetFileNames in datastore

### DIFF
--- a/src/datastore/datastore.go
+++ b/src/datastore/datastore.go
@@ -25,7 +25,7 @@ type DataStore struct {
 }
 
 func (d *DataStore) GetFileNames() []string {
-    filenames := make([]string, 0, len(d.data))
+    filenames := make([]string, len(d.data))
     i := 0
     for f, _ := range d.data {
         filenames[i] = f


### PR DESCRIPTION
The make command in GetFileNames was not correctly set up for indexing. Fixed and tested