### PR TITLE
refactor client out of cache master

### DIFF
--- a/src/task/client_test.go
+++ b/src/task/client_test.go
@@ -40,7 +40,11 @@ func TestClientSimpleWorkload(t *testing.T) {
 	for i := 0; i < numClients; i++ {
 		clients[i] = Init(i)
 	}
-	cachedIDMap, hash := StartTask(clients, config.LRU, config.CACHE_SIZE, numCaches, replicationFactor, data, syncCachesEveryMS)
+	clientIds := make([]int, len(clients))
+	for i := 0; i < len(clients); i++ {
+		clientIds[i] = clients[i].GetID()
+	}
+	cachedIDMap, hash := StartTask(clientIds, config.LRU, config.CACHE_SIZE, numCaches, replicationFactor, data, syncCachesEveryMS)
 	for i := 0; i < numClients; i++ {
 		clients[i].BootstrapClient(cachedIDMap, *hash, w)
 	}

--- a/src/task/task.go
+++ b/src/task/task.go
@@ -27,7 +27,11 @@ func NewAbstractBaseTask(numClients int, numCaches int, replicationFactor int, c
 	}
 
 	// make cache master
-	caches, hash := StartTask(clients, cacheType, cacheSize, numCaches, replicationFactor, datastore, ms)
+	clientIds := make([]int, len(clients))
+	for i := 0; i < len(clients); i++ {
+		clientIds[i] = clients[i].GetID()
+	}
+	caches, hash := StartTask(clientIds, cacheType, cacheSize, numCaches, replicationFactor, datastore, ms)
 
 	// TODO: add chache size
 


### PR DESCRIPTION
Small refactor to make the cache master lighter weight since it doesn't need to talk to the clients. StartTask only requires passing in clientId list.